### PR TITLE
Fix nearest to use a SQL literal ORDER BY

### DIFF
--- a/lib/sequel/plugins/pg_location.rb
+++ b/lib/sequel/plugins/pg_location.rb
@@ -26,7 +26,7 @@ module Sequel
           within(lat, lng, radius)
           .select_append{
             (Sequel::SQL::AliasedExpression.new(Sequel.function(:earth_distance, Sequel.function(:ll_to_earth,lat,lng), location_cache_field), :distance))
-          }.order(:distance.asc)
+          }.order(Sequel.asc(Sequel.lit("distance")))
         end
 
         def within(lat,lng,radius)


### PR DESCRIPTION
Otherwise Sequel tries to "ORDER BY 'distance'" which results in this error.  I don't know what changed in Sequel to break the code, or if this is the best way to fix it, but it gets it working again.

```
ERROR:  non-integer constant in ORDER BY at character 270
STATEMENT:  SELECT *, earth_distance(ll_to_earth(45.53657, -122.6618457), "ll_point") AS "distance" FROM "facilities" WHERE ((earth_box(ll_to_earth(45.53657,-122.6618457),16093.0) @> ll_point) AND (earth_distance(ll_to_earth(45.53657, -122.6618457), ll_point) < 16093.0)) ORDER BY 'distance'
```

Here's a demonstration of the basic problem in psql.

```
# select 1 as "distance" order by 'distance';
ERROR:  non-integer constant in ORDER BY
LINE 1: select 1 as "distance" order by 'distance';

# select 1 as "distance" order by distance;
 distance
 ----------
         1
         (1 row)
```
ruby 2.2.0p0
sequel 4.21.0
sequel-location 0.0.3
pg 0.18.1
PostgreSQL 9.4.1